### PR TITLE
Load vocabulary task

### DIFF
--- a/dags/dependencies/ehr/constants.py
+++ b/dags/dependencies/ehr/constants.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 # Main endpoint
-PROCESSOR_ENDPOINT = "https://ccc-omop-file-processor-1061430463455.us-central1.run.app"
+PROCESSOR_ENDPOINT = "https://ccc-omop-file-processor-eaf-1061430463455.us-central1.run.app"
 
 SITE_CONFIG_YML_PATH = "/home/airflow/gcs/dags/dependencies/ehr/config/site_config.yml"
 
@@ -12,15 +12,28 @@ PIPELINE_COMPLETE_STRING = "completed"
 PIPELINE_ERROR_STRING = "error"
 PIPELINE_DAG_FAIL_MESSAGE = "DAG failed"
 
+# When True, overwrites site provided vocabulary tables with target vocabulary tables from Athena
+LOAD_ONLY_TARGET_VOCAB = True
 TARGET_VOCAB_VERSION = "v5.0 30-AUG-24"
 VOCAB_REF_GCS_BUCKET = "ehr_pipeline_vocabulary_files"
+VOCABULARY_TABLES = [
+    "concept",
+    "concept_ancestor",
+    "concept_class",
+    "concept_relationship",
+    "concept_synonym",
+    "domain",
+    "drug_strength",
+    "relationship",
+    "vocabulary"
+]
 
 TARGET_CDM_VERSION = "5.4"
 
 CONDITION_ERA = "condition_era"
 DRUG_ERA = "drug_era"
 OBSERVATION_PERIOD = "observation_period"
-DERIVED_DATA_TABLES: list = [CONDITION_ERA, DRUG_ERA, OBSERVATION_PERIOD]
+DERIVED_DATA_TABLES: list = [DRUG_ERA, CONDITION_ERA, OBSERVATION_PERIOD]
 
 CSV = ".csv"
 PARQUET = ".parquet"
@@ -40,8 +53,9 @@ class ArtifactPaths(str, Enum):
     ARTIFACTS = "artifacts/"
     FIXED_FILES = f"{ARTIFACTS}fixed_files/"
     CONVERTED_FILES = f"{ARTIFACTS}converted_files/"
+    CREATED_FILES = f"{ARTIFACTS}created_files/"
     REPORT = f"{ARTIFACTS}delivery_report/"
     REPORT_TMP = f"{ARTIFACTS}delivery_report/tmp/"
     DQD = f"{ARTIFACTS}dqd/"
+    ACHILLES = f"{ARTIFACTS}achilles/"
     INVALID_ROWS = f"{ARTIFACTS}invalid_rows/"
-

--- a/dags/dependencies/ehr/omop.py
+++ b/dags/dependencies/ehr/omop.py
@@ -86,3 +86,16 @@ def populate_cdm_source(cdm_source_data: dict) -> None:
         endpoint="populate_cdm_source",
         json_data=cdm_source_data
     )
+
+def load_vocabulary_table_gcs_to_bq(vocab_version: str, vocab_gcs_bucket: str, table_file_name: str, project_id: str, dataset_id: str) -> None:
+    utils.logger.info(f"Loading {table_file_name} vocabulary table to {project_id}.{dataset_id}")
+    utils.make_api_call(
+        endpoint="load_target_vocab",
+        json_data={
+            "vocab_version": vocab_version,
+            "vocab_gcs_bucket": vocab_gcs_bucket,
+            "table_file_name": table_file_name,
+            "project_id": project_id,
+            "dataset_id": dataset_id,            
+        }
+    )


### PR DESCRIPTION
- Added configuration parameter LOAD_ONLY_TARGET_VOCAB. When True, the pipeline will overwrite any site-provided vocabulary tables with the tables from the target version specified in TARGET_VOCAB_VERSION. When False, the pipeline will _not_ overwrites tables, but will load any missing vocabulary tables not provided by the site.
- Rewrite prepare_bq task to function on each site independently, when processing deliveries from multiple sites
- Created load_target_vocab task to load vocabulary tables to BigQuery. This functions at the site level; a task will be created per site, and each site will iterate through a list of vocabulary tables to process.
- Closes sub-issue [#65](https://github.com/Analyticsphere/ehr-pilot/issues/65)