### PR TITLE
Last fixes

### DIFF
--- a/dags/dependencies/ehr/bq.py
+++ b/dags/dependencies/ehr/bq.py
@@ -1,6 +1,4 @@
 from dependencies.ehr import constants, utils
-from google.cloud import bigquery  # type: ignore
-from google.cloud.exceptions import NotFound  # type: ignore
 
 
 def load_parquet_to_bq(file_path: str, project_id: str, dataset_id: str, table_name: str, write_type: constants.BQWriteTypes) -> None:

--- a/dags/dependencies/ehr/bq.py
+++ b/dags/dependencies/ehr/bq.py
@@ -28,38 +28,26 @@ def prep_dataset(project_id: str, dataset_id: str) -> None:
         }
     )
 
-def get_bq_log_row(site, date_to_check) -> list:
-    client = bigquery.Client()
+def get_bq_log_row(site: str, delivery_date: str) -> list:
+    utils.logger.info(f"Getting logging data for {delivery_date} delivery from {site}")
 
-    # Check if the table exists. If it doesn't, return an empty list.
     try:
-        client.get_table(constants.PIPELINE_LOG_TABLE)
-    except NotFound:
-        # Table does not exist, so return an empty list without error.
+        response = utils.make_api_call(
+            endpoint="get_log_row",
+            method="get",
+            params={
+                "site": site,
+                "delivery_date": delivery_date,
+            }
+        )
+
+        if response and 'log_row' in response:
+            return response['log_row']
         return []
 
-    # Construct the query to retrieve logs for the given site and delivery date.
-    query = f"""
-        SELECT *
-        FROM `{constants.PIPELINE_LOG_TABLE}`
-        WHERE site_name = @site
-          AND delivery_date = @delivery_date
-    """
-
-    job_config = bigquery.QueryJobConfig(
-        query_parameters=[
-            bigquery.ScalarQueryParameter("site", "STRING", site),
-            bigquery.ScalarQueryParameter("delivery_date", "DATE", date_to_check),
-        ]
-    )
-
-    try:
-        query_job = client.query(query, job_config=job_config)
-        results = list(query_job.result())
-        return results
     except Exception as e:
-        utils.logger.error(f"Failed to retrieve BigQuery pipeline logs for site '{site}' and date '{date_to_check}': {e}")
-        raise Exception(f"Failed to retrieve BigQuery pipeline logs for site '{site}' and date '{date_to_check}': {e}") from e
+        utils.logger.error(f"Error getting logging data: {e}")
+        raise Exception(f"Error getting logging data: {e}") from e
 
 def bq_log_start(site: str, delivery_date: str, file_type: str, omop_version: str, run_id: str) -> None:
     status = constants.PIPELINE_START_STRING
@@ -67,7 +55,7 @@ def bq_log_start(site: str, delivery_date: str, file_type: str, omop_version: st
     utils.make_api_call(
         endpoint="pipeline_log",
         json_data={
-            "logging_table": constants.PIPELINE_LOG_TABLE,
+            #"logging_table": constants.PIPELINE_LOG_TABLE,
             "site_name": site,
             "delivery_date": delivery_date,
             "status": status,
@@ -83,7 +71,7 @@ def bq_log_running(site: str, delivery_date: str, run_id: str) -> None:
     utils.make_api_call(
         endpoint="pipeline_log",
         json_data={
-            "logging_table": constants.PIPELINE_LOG_TABLE,
+            #"logging_table": constants.PIPELINE_LOG_TABLE,
             "site_name": site,
             "delivery_date": delivery_date,
             "status": status,
@@ -97,7 +85,7 @@ def bq_log_error(site: str, delivery_date: str, run_id: str, message: str) -> No
     utils.make_api_call(
         endpoint="pipeline_log",
         json_data={
-            "logging_table": constants.PIPELINE_LOG_TABLE,
+            #"logging_table": constants.PIPELINE_LOG_TABLE,
             "site_name": site,
             "delivery_date": delivery_date,
             "status": status,
@@ -112,7 +100,7 @@ def bq_log_complete(site: str, delivery_date: str, run_id: str) -> None:
     utils.make_api_call(
         endpoint="pipeline_log",
         json_data={
-            "logging_table": constants.PIPELINE_LOG_TABLE,
+            #"logging_table": constants.PIPELINE_LOG_TABLE,
             "site_name": site,
             "delivery_date": delivery_date,
             "status": status,

--- a/dags/dependencies/ehr/bq.py
+++ b/dags/dependencies/ehr/bq.py
@@ -55,7 +55,6 @@ def bq_log_start(site: str, delivery_date: str, file_type: str, omop_version: st
     utils.make_api_call(
         endpoint="pipeline_log",
         json_data={
-            #"logging_table": constants.PIPELINE_LOG_TABLE,
             "site_name": site,
             "delivery_date": delivery_date,
             "status": status,
@@ -71,7 +70,6 @@ def bq_log_running(site: str, delivery_date: str, run_id: str) -> None:
     utils.make_api_call(
         endpoint="pipeline_log",
         json_data={
-            #"logging_table": constants.PIPELINE_LOG_TABLE,
             "site_name": site,
             "delivery_date": delivery_date,
             "status": status,
@@ -85,7 +83,6 @@ def bq_log_error(site: str, delivery_date: str, run_id: str, message: str) -> No
     utils.make_api_call(
         endpoint="pipeline_log",
         json_data={
-            #"logging_table": constants.PIPELINE_LOG_TABLE,
             "site_name": site,
             "delivery_date": delivery_date,
             "status": status,
@@ -100,7 +97,6 @@ def bq_log_complete(site: str, delivery_date: str, run_id: str) -> None:
     utils.make_api_call(
         endpoint="pipeline_log",
         json_data={
-            #"logging_table": constants.PIPELINE_LOG_TABLE,
             "site_name": site,
             "delivery_date": delivery_date,
             "status": status,

--- a/dags/dependencies/ehr/constants.py
+++ b/dags/dependencies/ehr/constants.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 # Main endpoint
-PROCESSOR_ENDPOINT = "https://ccc-omop-file-processor-eaf-1061430463455.us-central1.run.app"
+PROCESSOR_ENDPOINT = "https://ccc-omop-file-processor-155089172944.us-central1.run.app"
 
 SITE_CONFIG_YML_PATH = "/home/airflow/gcs/dags/dependencies/ehr/config/site_config.yml"
 

--- a/dags/dependencies/ehr/constants.py
+++ b/dags/dependencies/ehr/constants.py
@@ -5,7 +5,6 @@ PROCESSOR_ENDPOINT = "https://ccc-omop-file-processor-eaf-1061430463455.us-centr
 
 SITE_CONFIG_YML_PATH = "/home/airflow/gcs/dags/dependencies/ehr/config/site_config.yml"
 
-PIPELINE_LOG_TABLE = "nih-nci-dceg-connect-dev.ehr_pipeline_metadata.pipeline_runs"
 PIPELINE_START_STRING = "started"
 PIPELINE_RUNNING_STRING = "running"
 PIPELINE_COMPLETE_STRING = "completed"
@@ -15,7 +14,6 @@ PIPELINE_DAG_FAIL_MESSAGE = "DAG failed"
 # When True, overwrites site provided vocabulary tables with target vocabulary tables from Athena
 LOAD_ONLY_TARGET_VOCAB = True
 TARGET_VOCAB_VERSION = "v5.0 30-AUG-24"
-VOCAB_REF_GCS_BUCKET = "ehr_pipeline_vocabulary_files"
 VOCABULARY_TABLES = [
     "concept",
     "concept_ancestor",
@@ -27,6 +25,7 @@ VOCABULARY_TABLES = [
     "relationship",
     "vocabulary"
 ]
+
 VOCAB_HARMONIZED_TABLES = [
     "visit_occurrence",
     "condition_occurrence",

--- a/dags/dependencies/ehr/omop.py
+++ b/dags/dependencies/ehr/omop.py
@@ -52,7 +52,7 @@ def create_missing_omop_tables(project_id: str, dataset_id: str, omop_version: s
         }
     )
 
-def create_derived_data_table(site: str, gcs_bucket: str, delivery_date: str, table_name: str, project_id: str, dataset_id: str, vocab_version: str, vocab_gcs_bucket: str) -> None:
+def create_derived_data_table(site: str, gcs_bucket: str, delivery_date: str, table_name: str, project_id: str, dataset_id: str, vocab_version: str) -> None:
     utils.logger.info(f"Generating derived data table {table_name} for {delivery_date} delivery from {site}")
 
     utils.make_api_call(
@@ -64,8 +64,7 @@ def create_derived_data_table(site: str, gcs_bucket: str, delivery_date: str, ta
             "table_name": table_name,
             "project_id": project_id,
             "dataset_id": dataset_id,
-            "vocab_version": vocab_version,
-            "vocab_gcs_bucket": vocab_gcs_bucket
+            "vocab_version": vocab_version
         }
     )
 

--- a/dags/dependencies/ehr/vocab.py
+++ b/dags/dependencies/ehr/vocab.py
@@ -1,13 +1,12 @@
 from dependencies.ehr import utils
 
 
-def load_vocabulary_table_gcs_to_bq(vocab_version: str, vocab_gcs_bucket: str, table_file_name: str, project_id: str, dataset_id: str) -> None:
+def load_vocabulary_table_gcs_to_bq(vocab_version: str, table_file_name: str, project_id: str, dataset_id: str) -> None:
     utils.logger.info(f"Loading {table_file_name} vocabulary table to {project_id}.{dataset_id}")
     utils.make_api_call(
         endpoint="load_target_vocab",
         json_data={
             "vocab_version": vocab_version,
-            "vocab_gcs_bucket": vocab_gcs_bucket,
             "table_file_name": table_file_name,
             "project_id": project_id,
             "dataset_id": dataset_id,
@@ -15,25 +14,23 @@ def load_vocabulary_table_gcs_to_bq(vocab_version: str, vocab_gcs_bucket: str, t
     )
 
 
-def create_optimized_vocab(vocab_version: str, vocab_gcs_bucket: str) -> None:
+def create_optimized_vocab(vocab_version: str) -> None:
     utils.logger.info(f"Creating optimized version of {vocab_version} if required")
 
     utils.make_api_call(
         endpoint="create_optimized_vocab",
         json_data={
-            "vocab_version": vocab_version,
-            "vocab_gcs_bucket": vocab_gcs_bucket
+            "vocab_version": vocab_version
         }
     )
 
-def harmonize(vocab_version: str, vocab_gcs_bucket: str, omop_version: str, file_path: str, site: str, project_id: str, dataset_id: str) -> None:
+def harmonize(vocab_version: str, omop_version: str, file_path: str, site: str, project_id: str, dataset_id: str) -> None:
     utils.logger.info(f"Standardizing {file_path} to vocabulary version {vocab_version}")
 
     utils.make_api_call(
         endpoint="harmonize_vocab",
         json_data={
             "vocab_version": vocab_version,
-            "vocab_gcs_bucket": vocab_gcs_bucket,
             "omop_version": omop_version,
             "file_path": file_path,
             "site": site,

--- a/dags/ehr_pipeline.py
+++ b/dags/ehr_pipeline.py
@@ -54,7 +54,7 @@ def prepare_for_run() -> list[tuple[str, str]]:
     sites = utils.get_site_list()
 
     # Generate the optimized vocabulary files
-    vocab.create_optimized_vocab(constants.TARGET_VOCAB_VERSION, constants.VOCAB_REF_GCS_BUCKET)
+    vocab.create_optimized_vocab(constants.TARGET_VOCAB_VERSION)
 
     for site in sites:
         delivery_date_to_check = utils.get_most_recent_folder(site)
@@ -220,7 +220,7 @@ def harmonize_vocab(file_config: dict) -> None:
         else:
             project_id = utils.get_site_config_file()[constants.FileConfig.SITE.value][site][constants.FileConfig.PROJECT_ID.value]
             dataset_id = utils.get_site_config_file()[constants.FileConfig.SITE.value][site][constants.FileConfig.BQ_DATASET.value]
-            vocab.harmonize(constants.TARGET_VOCAB_VERSION, constants.VOCAB_REF_GCS_BUCKET, constants.TARGET_CDM_VERSION, file_path, site, project_id, dataset_id)
+            vocab.harmonize(constants.TARGET_VOCAB_VERSION, constants.TARGET_CDM_VERSION, file_path, site, project_id, dataset_id)
     except AirflowException:
         # Re-raise the skip exception without logging it as an error
         raise
@@ -268,7 +268,6 @@ def load_target_vocab(site_to_process: tuple[str, str]) -> None:
         try:
             vocab.load_vocabulary_table_gcs_to_bq(
                 constants.TARGET_VOCAB_VERSION, 
-                constants.VOCAB_REF_GCS_BUCKET,
                 vocab_table,
                 project_id,
                 dataset_id
@@ -319,7 +318,7 @@ def derived_data_tables(site_to_process: tuple[str, str]) -> None:
         gcs_bucket = utils.get_site_config_file()[constants.FileConfig.SITE.value][site][constants.FileConfig.GCS_BUCKET.value]
     
         for dervied_table in constants.DERIVED_DATA_TABLES:
-            omop.create_derived_data_table(site, gcs_bucket, delivery_date, dervied_table, project_id, dataset_id, constants.TARGET_VOCAB_VERSION, constants.VOCAB_REF_GCS_BUCKET)
+            omop.create_derived_data_table(site, gcs_bucket, delivery_date, dervied_table, project_id, dataset_id, constants.TARGET_VOCAB_VERSION)
         
     except Exception as e:
         bq.bq_log_error(site, delivery_date, utils.get_run_id(get_current_context()), str(e))

--- a/dags/ehr_pipeline.py
+++ b/dags/ehr_pipeline.py
@@ -110,7 +110,6 @@ def get_files(sites_to_process: list[tuple[str, str]]) -> list[dict]:
                 file_configs.append(file_config_obj.to_dict())
         except Exception as e:
             error_msg = f"Unable to get file list: {str(e)}"
-            utils.logger.error(error_msg)
             bq.bq_log_error(site, delivery_date, run_id, str(e))
             raise Exception(error_msg) from e
 
@@ -226,7 +225,6 @@ def harmonize_vocab(file_config: dict) -> None:
         raise
     except Exception as e:
         error_msg = f"Unable to harmonize vocabulary of file: {e}"
-        utils.logger.error(error_msg)
         bq.bq_log_error(site, delivery_date, utils.get_run_id(get_current_context()), str(e))
         raise Exception(error_msg) from e            
 


### PR DESCRIPTION
- Remove BigQuery logging table and GCS vocab bucket. Values are now environment variables defined in Cloud Run configuration.
- Move get_bq_log_row() functionality to omop-file-processor repo and replace with API call