### PR TITLE
Expanded logging + new report file task

### DIFF
--- a/dags/dependencies/ehr/analysis.py
+++ b/dags/dependencies/ehr/analysis.py
@@ -10,10 +10,12 @@ def run_dqd_job(
     gcs_artifact_path: str,
     cdm_version: str,
     cdm_source_name: str,
-    context
+    context,
+    site: str = None,
+    delivery_date: str = None
 ) -> None:
     """
-    Execute DQD via Cloud Run Job.
+    Execute DQD (Data Quality Dashboard) via Cloud Run Job.
 
     DQD runs can take 2+ hours, exceeding the 1-hour Cloud Run service timeout.
     This function triggers a Cloud Run Job that can run up to 24 hours.
@@ -21,15 +23,19 @@ def run_dqd_job(
     Args:
         project_id: Google Cloud project ID
         dataset_id: BigQuery dataset ID
+        analytics_dataset_id: BigQuery analytics dataset ID
         gcs_artifact_path: GCS path for artifacts
         cdm_version: OMOP CDM version (e.g., "5.4")
         cdm_source_name: Human-friendly name for the CDM source
         context: Airflow task context
+        site: Optional site identifier for logging context
+        delivery_date: Optional delivery date for logging context
 
     Raises:
         Exception: If Cloud Run Job fails
     """
-    utils.logger.info(f"Executing DQD Cloud Run Job for {project_id}.{dataset_id}")
+    log_ctx = utils.format_log_context(site=site, delivery_date=delivery_date)
+    utils.logger.info(f"{log_ctx}Executing DQD (Data Quality Dashboard) Cloud Run Job for: {project_id}.{dataset_id}")
 
     # Create and execute Cloud Run Job operator
     operator = CloudRunExecuteJobOperator(
@@ -54,7 +60,7 @@ def run_dqd_job(
 
     # Execute the Cloud Run Job
     operator.execute(context=context)
-    utils.logger.info(f"DQD Cloud Run Job completed successfully for {project_id}.{dataset_id}")
+    utils.logger.info(f"{log_ctx}DQD Cloud Run Job completed successfully for: {project_id}.{dataset_id}")
 
 
 def run_achilles_job(
@@ -64,7 +70,9 @@ def run_achilles_job(
     gcs_artifact_path: str,
     cdm_version: str,
     cdm_source_name: str,
-    context
+    context,
+    site: str = None,
+    delivery_date: str = None
 ) -> None:
     """
     Execute Achilles analyses via Cloud Run Job.
@@ -81,11 +89,14 @@ def run_achilles_job(
         cdm_version: OMOP CDM version (e.g., "5.4")
         cdm_source_name: Human-friendly name for the CDM source
         context: Airflow task context
+        site: Optional site identifier for logging context
+        delivery_date: Optional delivery date for logging context
 
     Raises:
         Exception: If Cloud Run Job fails
     """
-    utils.logger.info(f"Executing Achilles Cloud Run Job for CDM dataset {project_id}.{dataset_id}, writing results to {project_id}.{analytics_dataset_id}")
+    log_ctx = utils.format_log_context(site=site, delivery_date=delivery_date)
+    utils.logger.info(f"{log_ctx}Executing Achilles Cloud Run Job - CDM dataset: {project_id}.{dataset_id}, Results dataset: {project_id}.{analytics_dataset_id}")
 
     # Create and execute Cloud Run Job operator
     operator = CloudRunExecuteJobOperator(
@@ -110,13 +121,15 @@ def run_achilles_job(
 
     # Execute the Cloud Run Job
     operator.execute(context=context)
-    utils.logger.info(f"Achilles Cloud Run Job completed successfully for {project_id}.{dataset_id}")
+    utils.logger.info(f"{log_ctx}Achilles Cloud Run Job completed successfully for: {project_id}.{dataset_id}")
 
 
 def create_atlas_results_tables(
     project_id: str,
     cdm_dataset_id: str,
-    analytics_dataset_id: str
+    analytics_dataset_id: str,
+    site: str = None,
+    delivery_date: str = None
 ) -> None:
     """
     Create Atlas results tables in BigQuery by calling the OMOP analyzer API.
@@ -128,11 +141,15 @@ def create_atlas_results_tables(
         project_id: Google Cloud project ID
         cdm_dataset_id: BigQuery CDM dataset ID
         analytics_dataset_id: BigQuery dataset ID where Atlas results tables will be created
+        site: Optional site identifier for logging context
+        delivery_date: Optional delivery date for logging context
 
     Raises:
         Exception: If API call fails
     """
-    utils.logger.info(f"Creating Atlas results tables in {project_id}.{analytics_dataset_id}")
+    
+    log_ctx = utils.format_log_context(site=site, delivery_date=delivery_date)
+    utils.logger.info(f"{log_ctx}Creating Atlas results tables in: {project_id}.{analytics_dataset_id}")
 
     # Call the API endpoint
     response = utils.make_api_call(
@@ -144,12 +161,13 @@ def create_atlas_results_tables(
             "cdm_dataset_id": cdm_dataset_id,
             "analytics_dataset_id": analytics_dataset_id
         },
-        timeout=300  # 5 minute timeout
+        timeout=300,  # 5 minute timeout
+        site=site,
+        delivery_date=delivery_date
     )
 
     if response and response.get('status') == 'success':
-        utils.logger.info(f"Atlas results tables created successfully in {project_id}.{analytics_dataset_id}")
+        utils.logger.info(f"{log_ctx}Atlas results tables created successfully in: {project_id}.{analytics_dataset_id}")
     else:
-        error_msg = f"Failed to create Atlas results tables: {response}"
-        utils.logger.error(error_msg)
+        error_msg = f"{log_ctx}Failed to create Atlas results tables: {response}"
         raise Exception(error_msg)

--- a/dags/dependencies/ehr/dag_helpers.py
+++ b/dags/dependencies/ehr/dag_helpers.py
@@ -190,3 +190,10 @@ def extract_site_and_date(site_to_process: tuple[str, str]) -> tuple[str, str]:
         Tuple of (site, delivery_date)
     """
     return site_to_process
+
+
+# Re-export logging utility functions from utils module
+# These are defined in utils.py to avoid circular imports
+format_log_context = utils.format_log_context
+extract_context_from_file_config = utils.extract_context_from_file_config
+extract_context_from_site_tuple = utils.extract_context_from_site_tuple

--- a/dags/dependencies/ehr/processing.py
+++ b/dags/dependencies/ehr/processing.py
@@ -1,17 +1,29 @@
 from dependencies.ehr import constants, utils
 from dependencies.ehr.storage_backend import storage
+from dependencies.ehr.utils import format_log_context
 
 
 def get_file_list(site: str, delivery_date: str, file_format: str) -> list[str]:
     """
-    Get a list of files from a site's latest delivery
+    Get a list of files from a site's latest delivery.
+
+    Args:
+        site: Site identifier
+        delivery_date: Delivery date (YYYY-MM-DD format)
+        file_format: File format filter (e.g., '.csv', '.parquet')
+
+    Returns:
+        List of file paths found in the delivery bucket
     """
+    
+
     try:
         gcs_bucket = utils.get_site_bucket(site=site)
         full_path = f"{gcs_bucket}/{delivery_date}"
-        create_artifact_directories(delivery_bucket=full_path)
+        create_artifact_directories(delivery_bucket=full_path, site=site, delivery_date=delivery_date)
 
-        utils.logger.info(f"Getting files for {delivery_date} delivery from {site}")
+        log_ctx = format_log_context(site=site, delivery_date=delivery_date)
+        utils.logger.info(f"{log_ctx}Discovering {file_format} files in delivery bucket: {full_path}")
 
         response = utils.make_api_call(
             url=constants.OMOP_PROCESSOR_ENDPOINT,
@@ -21,50 +33,86 @@ def get_file_list(site: str, delivery_date: str, file_format: str) -> list[str]:
                 "bucket": gcs_bucket,
                 "folder": delivery_date,
                 "file_format": file_format
-            }
+            },
+            site=site,
+            delivery_date=delivery_date
         )
 
         if response and 'file_list' in response:
-            return response['file_list']
+            file_list = response['file_list']
+            utils.logger.info(f"{log_ctx}Discovered {len(file_list)} file(s) to process")
+            return file_list
+        utils.logger.info(f"{log_ctx}No files found matching format: {file_format}")
         return []
 
     except Exception as e:
-        utils.logger.error(f"Error getting file list: {e}")
-        raise Exception(f"Error getting file list: {e}") from e
+        log_ctx = format_log_context(site=site, delivery_date=delivery_date)
+        raise Exception(f"{log_ctx}Error getting file list: {e}") from e
 
-def create_artifact_directories(delivery_bucket: str) -> None:
+def create_artifact_directories(delivery_bucket: str, site: str = None, delivery_date: str = None) -> None:
     """
-    Create artifact directories in the parent bucket for storing processing artifacts
+    Create artifact directories in the parent bucket for storing processing artifacts.
+
+    Args:
+        delivery_bucket: Full GCS path to delivery bucket (bucket/delivery_date)
+        site: Optional site identifier for logging context
+        delivery_date: Optional delivery date for logging context
     """
-    utils.logger.info(f"Creating artifact directories in {delivery_bucket}")
+    
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date)
+    utils.logger.info(f"{log_ctx}Creating artifact directories in: {delivery_bucket}")
 
     utils.make_api_call(
         url=constants.OMOP_PROCESSOR_ENDPOINT,
         endpoint="create_artifact_directories",
-        json_data={"delivery_bucket": delivery_bucket}
+        json_data={"delivery_bucket": delivery_bucket},
+        site=site,
+        delivery_date=delivery_date
     )
 
-def process_file(file_type: str, gcs_file_path: str) -> None:
+def process_file(file_type: str, gcs_file_path: str, site: str = None, delivery_date: str = None) -> None:
     """
     Create optimized version of incoming EHR data file.
+
+    Args:
+        file_type: OMOP table name
+        gcs_file_path: Full GCS path to the file
+        site: Optional site identifier for logging context
+        delivery_date: Optional delivery date for logging context
     """
-    utils.logger.info(f"Processing incoming {file_type} file {storage.get_uri(gcs_file_path)}")
     
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=file_type)
+    utils.logger.info(f"{log_ctx}Processing incoming file: {storage.get_uri(gcs_file_path)}")
+
     utils.make_api_call(
         url=constants.OMOP_PROCESSOR_ENDPOINT,
         endpoint="process_incoming_file",
         json_data={
             "file_type": file_type,
             "file_path": gcs_file_path
-        }
+        },
+        site=site,
+        delivery_date=delivery_date,
+        file=file_type
     )
 
-def normalize_parquet_file(file_path: str, cdm_version: str, date_format: str, datetime_format: str) -> None:
+def normalize_parquet_file(file_path: str, cdm_version: str, date_format: str, datetime_format: str, site: str = None, delivery_date: str = None, file: str = None) -> None:
     """
     Standardize OMOP data file structure.
+
+    Args:
+        file_path: GCS path to Parquet file
+        cdm_version: OMOP CDM version
+        date_format: Date format string
+        datetime_format: Datetime format string
+        site: Optional site identifier for logging context
+        delivery_date: Optional delivery date for logging context
+        file: Optional file/table name for logging context
     """
-    utils.logger.info(f"Normalizing file {storage.get_uri(file_path)}")
     
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=file)
+    utils.logger.info(f"{log_ctx}Normalizing Parquet file (CDM {cdm_version})")
+
     utils.make_api_call(
         url=constants.OMOP_PROCESSOR_ENDPOINT,
         endpoint="normalize_parquet",
@@ -73,6 +121,9 @@ def normalize_parquet_file(file_path: str, cdm_version: str, date_format: str, d
             "omop_version": cdm_version,
             "date_format": date_format,
             "datetime_format": datetime_format
-        }
+        },
+        site=site,
+        delivery_date=delivery_date,
+        file=file
     )
 

--- a/dags/dependencies/ehr/processing_jobs.py
+++ b/dags/dependencies/ehr/processing_jobs.py
@@ -5,14 +5,6 @@ This module provides functions to execute long-running file processing operation
 as Google Cloud Run Jobs instead of HTTP API calls. Cloud Run Jobs can run up to
 24 hours (vs 1 hour limit for Cloud Run Services), making them suitable for
 large file processing tasks.
-
-Jobs executed by this module:
-    - process_file: Convert CSV/CSV.GZ to Parquet
-    - normalize_parquet: Standardize data types and formats
-    - upgrade_cdm: Upgrade CDM versions (e.g., 5.3 to 5.4)
-    - harmonize_vocab: 8-step vocabulary harmonization process
-    - generate_derived_tables: Generate observation_period, condition_era, drug_era
-    - generate_report_csv: Generate delivery report CSV with metadata and statistics
 """
 
 import json
@@ -21,24 +13,21 @@ from airflow.providers.google.cloud.operators.cloud_run import \
     CloudRunExecuteJobOperator
 from dependencies.ehr import constants, utils
 from dependencies.ehr.storage_backend import storage
+from dependencies.ehr.utils import format_log_context
 
 
 def run_process_file_job(
     file_type: str,
     gcs_file_path: str,
     project_id: str,
-    context
+    context,
+    site: str = None,
+    delivery_date: str = None
 ) -> None:
-    """
-    Execute file processing as a Cloud Run Job (CSV/CSV.GZ to Parquet).
-
-    Args:
-        file_type: Type of OMOP table (e.g., 'person', 'condition_occurrence')
-        gcs_file_path: Full GCS path to the file (gs://bucket/path/file.csv)
-        project_id: GCP project ID
-        context: Airflow task context
-    """
-    utils.logger.info(f"Executing process_file job for {file_type}: {gcs_file_path}")
+    """Execute file processing as a Cloud Run Job (CSV/CSV.GZ to Parquet)"""
+    
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=file_type)
+    utils.logger.info(f"{log_ctx}Executing process_file Cloud Run Job for file: {gcs_file_path}")
 
     # Sanitize file_type for task_id (dots are not allowed in Airflow task IDs)
     sanitized_file_type = file_type.replace('.', '_')
@@ -68,7 +57,10 @@ def run_normalize_parquet_job(
     date_format: str,
     datetime_format: str,
     project_id: str,
-    context
+    context,
+    site: str = None,
+    delivery_date: str = None,
+    file: str = None
 ) -> None:
     """
     Execute Parquet normalization as a Cloud Run Job.
@@ -80,8 +72,13 @@ def run_normalize_parquet_job(
         datetime_format: Datetime format string (e.g., '%Y-%m-%d %H:%M:%S')
         project_id: GCP project ID
         context: Airflow task context
+        site: Optional site identifier for logging context
+        delivery_date: Optional delivery date for logging context
+        file: Optional file/table name for logging context
     """
-    utils.logger.info(f"Executing normalize_parquet job for: {file_path}")
+    
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=file)
+    utils.logger.info(f"{log_ctx}Executing normalize_parquet Cloud Run Job (CDM {cdm_version})")
 
     operator = CloudRunExecuteJobOperator(
         task_id=f'normalize_parquet_job',
@@ -109,7 +106,10 @@ def run_upgrade_cdm_job(
     cdm_version: str,
     target_cdm_version: str,
     project_id: str,
-    context
+    context,
+    site: str = None,
+    delivery_date: str = None,
+    file: str = None
 ) -> None:
     """
     Execute CDM upgrade as a Cloud Run Job.
@@ -120,8 +120,13 @@ def run_upgrade_cdm_job(
         target_cdm_version: Target OMOP CDM version
         project_id: GCP project ID
         context: Airflow task context
+        site: Optional site identifier for logging context
+        delivery_date: Optional delivery date for logging context
+        file: Optional file/table name for logging context
     """
-    utils.logger.info(f"Executing upgrade_cdm job: {file_path} from {cdm_version} to {target_cdm_version}")
+    
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=file)
+    utils.logger.info(f"{log_ctx}Executing upgrade_cdm Cloud Run Job: {cdm_version} → {target_cdm_version}")
 
     operator = CloudRunExecuteJobOperator(
         task_id=f'upgrade_cdm_job',
@@ -150,7 +155,8 @@ def run_harmonize_vocab_job(
     dataset_id: str,
     step: str,
     context,
-    output_gcs_path: str = ""
+    output_gcs_path: str = "",
+    delivery_date: str = None
 ) -> None:
     """
     Execute vocabulary harmonization step as a Cloud Run Job.
@@ -164,8 +170,14 @@ def run_harmonize_vocab_job(
               domain_check, omop_etl, consolidate_etl, discover_tables_for_dedup, deduplicate_single_table)
         context: Airflow task context
         output_gcs_path: Optional GCS path to write results (for discover_tables step)
+        delivery_date: Optional delivery date for logging context
     """
-    utils.logger.info(f"Executing harmonize_vocab job - Step: {step}, File: {file_path}")
+    
+
+    # Extract table name from file_path if available
+    file_name = file_path.split('/')[-1] if file_path else None
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=file_name)
+    utils.logger.info(f"{log_ctx}Executing harmonize_vocab Cloud Run Job - Step: {step}")
 
     env_vars = [
         {'name': 'FILE_PATH', 'value': file_path},
@@ -227,8 +239,11 @@ def run_discover_tables_job(
     # Construct output path for results
     output_gcs_path = f"{gcs_bucket}/{delivery_date}/artifacts/temp/table_configs_{site}.json"
 
-    utils.logger.info(f"Discovering tables for deduplication for site {site}")
-    utils.logger.info(f"Results will be written to: {storage.get_uri(output_gcs_path)}")
+    
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date)
+
+    utils.logger.info(f"{log_ctx}Discovering tables requiring deduplication")
+    utils.logger.info(f"{log_ctx}Results will be written to: {storage.get_uri(output_gcs_path)}")
 
     # Execute the job
     run_harmonize_vocab_job(
@@ -238,7 +253,8 @@ def run_discover_tables_job(
         dataset_id=dataset_id,
         step=constants.DISCOVER_TABLES_FOR_DEDUP,
         context=context,
-        output_gcs_path=output_gcs_path
+        output_gcs_path=output_gcs_path,
+        delivery_date=delivery_date
     )
 
     # Read results from GCS
@@ -260,11 +276,11 @@ def run_discover_tables_job(
         table_configs_json = blob.download_as_text()
         table_configs = json.loads(table_configs_json)
 
-        utils.logger.info(f"Discovered {len(table_configs)} table(s) for deduplication")
+        utils.logger.info(f"{log_ctx}Discovered {len(table_configs)} table(s) requiring deduplication")
         return table_configs
 
     except Exception as e:
-        utils.logger.error(f"Failed to read table configs from GCS: {e}")
+        utils.logger.error(f"{log_ctx}Failed to read table configs from GCS: {e}")
         # Return empty list if file doesn't exist or can't be read
         return []
 
@@ -284,13 +300,17 @@ def run_deduplicate_table_job(
             - project_id: Google Cloud project ID
             - dataset_id: BigQuery dataset ID
             - cdm_version: CDM version
+            - delivery_date: Optional delivery date
         context: Airflow task context
     """
     table_name = table_config.get('table_name', 'unknown')
     site = table_config.get('site', 'unknown')
     project_id = table_config['project_id']
+    delivery_date = table_config.get('delivery_date')
 
-    utils.logger.info(f"Executing deduplicate_table job for {table_name} from site {site}")
+    
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=table_name)
+    utils.logger.info(f"{log_ctx}Executing deduplicate_table Cloud Run Job")
 
     # Pass the table config as JSON string in the file_path parameter
     operator = CloudRunExecuteJobOperator(
@@ -341,7 +361,9 @@ def run_generate_derived_table_job(
         project_id: GCP project ID
         context: Airflow task context
     """
-    utils.logger.info(f"Executing generate_derived_table job: {table_name} for {site}")
+    
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=table_name)
+    utils.logger.info(f"{log_ctx}Executing generate_derived_table Cloud Run Job")
 
     operator = CloudRunExecuteJobOperator(
         task_id=f'generate_derived_table_job_{table_name}',
@@ -396,7 +418,9 @@ def run_generate_report_csv_job(
         project_id: GCP project ID
         context: Airflow task context
     """
-    utils.logger.info(f"Executing generate_report_csv job for {site} - {delivery_date}")
+    
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date)
+    utils.logger.info(f"{log_ctx}Executing generate_report_csv Cloud Run Job")
 
     operator = CloudRunExecuteJobOperator(
         task_id=f'generate_report_csv_job',

--- a/dags/dependencies/ehr/utils.py
+++ b/dags/dependencies/ehr/utils.py
@@ -20,6 +20,86 @@ logging.basicConfig(
 # Create the logger at module level so its settings are applied throughout code base
 logger = logging.getLogger(__name__)
 
+
+def format_log_context(
+    site: Optional[str] = None,
+    delivery_date: Optional[str] = None,
+    file: Optional[str] = None
+) -> str:
+    """
+    Format contextual information for log messages.
+
+    Creates a consistent, concise context prefix for log messages that includes
+    site, delivery_date, and/or file information. This makes logs easily searchable
+    and filterable in Cloud Logging.
+
+    Args:
+        site: Site name (e.g., 'synthea_54')
+        delivery_date: Delivery date in YYYY-MM-DD format
+        file: Filename, table name, or file path
+
+    Returns:
+        Formatted context string like "[site|delivery_date|file]" or subset.
+        Returns empty string if no context provided.
+
+    Examples:
+        >>> format_log_context(site="synthea_54", delivery_date="2024-01-15", file="person.csv")
+        "[synthea_54|2024-01-15|person.csv] "
+        >>> format_log_context(site="synthea_54", delivery_date="2024-01-15")
+        "[synthea_54|2024-01-15] "
+        >>> format_log_context(site="synthea_54")
+        "[synthea_54] "
+        >>> format_log_context()
+        ""
+    """
+    parts = []
+    if site:
+        parts.append(site)
+    if delivery_date:
+        parts.append(delivery_date)
+    if file:
+        parts.append(file)
+
+    return f"[{'|'.join(parts)}] " if parts else ""
+
+
+def extract_context_from_file_config(file_config_dict: dict) -> dict[str, Optional[str]]:
+    """
+    Extract site, delivery_date, and file context from a file_config_dict.
+
+    Args:
+        file_config_dict: Dictionary containing file configuration (from FileConfig.to_dict())
+
+    Returns:
+        Dict with keys: site, delivery_date, file (source_file or table_name)
+    """
+    return {
+        'site': file_config_dict.get(constants.FileConfig.SITE.value),
+        'delivery_date': file_config_dict.get(constants.FileConfig.DELIVERY_DATE.value),
+        'file': (
+            file_config_dict.get(constants.FileConfig.SOURCE_FILE.value) or
+            file_config_dict.get(constants.FileConfig.TABLE_NAME.value)
+        )
+    }
+
+
+def extract_context_from_site_tuple(site_to_process: tuple[str, str]) -> dict[str, Optional[str]]:
+    """
+    Extract site and delivery_date context from a site_to_process tuple.
+
+    Args:
+        site_to_process: Tuple of (site, delivery_date)
+
+    Returns:
+        Dict with keys: site, delivery_date, file (None)
+    """
+    site, delivery_date = site_to_process
+    return {
+        'site': site,
+        'delivery_date': delivery_date,
+        'file': None
+    }
+
 def get_gcloud_token() -> str:
     """
     Get identity token from gcloud CLI
@@ -32,7 +112,6 @@ def get_gcloud_token() -> str:
         ).strip()
         return token
     except subprocess.CalledProcessError as e:
-        logger.error(f"Failed to get gcloud token: {e}")
         raise Exception(f"Failed to get gcloud token: {e}") from e
 
 def get_auth_header() -> dict[str, str]:
@@ -57,10 +136,8 @@ def check_service_health(base_url: str) -> dict:
         return response.json()
         
     except subprocess.CalledProcessError as e:
-        logger.error(f"Error getting authentication token: {e}")
         raise Exception(f"Error getting authentication token: {e}") from e
     except requests.exceptions.RequestException as e:
-        logger.error(f"Error checking service health: {e}")
         raise Exception(f"Error checking service health: {e}") from e
 
 def get_site_bucket(site: str) -> str:
@@ -91,7 +168,6 @@ def get_site_config_file() -> dict:
 
         return config
     except Exception as e:
-        logger.error(f"Unable to get site configuration file: {e}")
         raise Exception(f"Unable to get site configuration file: {e}") from e
 
 def get_site_list() -> list[str]:
@@ -107,10 +183,18 @@ def get_most_recent_folder(site: str) -> str:
     """
     Find the most recent date-formatted folder in a GCS bucket.
 
+    Args:
+        site: Site name to find delivery dates for
+
+    Returns:
+        Most recent folder name in YYYY-MM-DD format
+
     Raises:
         Exception: If no date-formatted folders are found in the bucket
     """
     gcs_bucket = get_site_bucket(site)
+
+    logger.info(f"[{site}] Searching for most recent delivery date in bucket {gcs_bucket}")
 
     storage_client = storage.Client()
     bucket = storage_client.get_bucket(gcs_bucket)
@@ -145,8 +229,9 @@ def get_most_recent_folder(site: str) -> str:
             continue
 
     if most_recent_folder is None:
-        raise Exception(f"No date-formatted folders found in bucket {gcs_bucket} for site {site}")
+        raise Exception(f"[{site}] No date-formatted folders found in bucket {gcs_bucket}")
 
+    logger.info(f"[{site}] Found most recent delivery date: {most_recent_folder}")
     return most_recent_folder
 
 def get_run_id(airflow_context) -> str:
@@ -170,16 +255,34 @@ def make_api_call(
                  method: str = "post",
                  params: Optional[Dict[str, str]] = None,
                  json_data: Optional[Dict[str, Any]] = None,
-                 timeout: Optional[Union[float, Tuple[float, float]]] = None
+                 timeout: Optional[Union[float, Tuple[float, float]]] = None,
+                 site: Optional[str] = None,
+                 delivery_date: Optional[str] = None,
+                 file: Optional[str] = None
                  ) -> Optional[Any]:
     """
     Makes an API call to the processor endpoint with standardized error handling.
+
+    Args:
+        url: Base URL of the API
+        endpoint: Specific endpoint path
+        method: HTTP method (get or post)
+        params: Query parameters for GET requests
+        json_data: JSON body for POST requests
+        timeout: Request timeout
+        site: Optional site name for logging context
+        delivery_date: Optional delivery date for logging context
+        file: Optional file/table name for logging context
     """
+    # Import here to avoid circular dependency
+    
+
     api_call_url = f"{url}/{endpoint}"
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date, file=file)
 
     # pipeline_log calls are made often and clutter the logs, don't display this message
     if endpoint != "pipeline_log":
-        logger.info(f"Making {method.upper()} request to {url}")
+        logger.info(f"{log_ctx}Making {method.upper()} request to {endpoint}")
     
     try:
         if method.lower() == "get":
@@ -199,11 +302,10 @@ def make_api_call(
         
         # Check if the request was successful (accept any 2xx response)
         if not (200 <= response.status_code < 300):
-            error_message = f"API Error {response.status_code} from {endpoint}: {response.text}"
-            logger.error(error_message)
+            error_message = f"{log_ctx}API Error {response.status_code} from {endpoint}: {response.text}"
             raise Exception(error_message)
         else:
-            logger.info(f"API call to {endpoint} successful: {response.text}")
+            logger.info(f"{log_ctx}API call to {endpoint} successful: {response.text}")
         
         # Try to parse as JSON, but handle non-JSON responses
         if response.content:
@@ -217,13 +319,11 @@ def make_api_call(
     except requests.exceptions.JSONDecodeError as e:
         # This shouldn't normally be reached with the try/except above,
         # but keeping it as a fallback
-        logger.warning(f"Response from {endpoint} was not valid JSON: {response.text}")
+        logger.warning(f"{log_ctx}Response from {endpoint} was not valid JSON: {response.text}")
         return response.text
     except subprocess.CalledProcessError as e:
-        error_msg = f"Error getting authentication token for {endpoint}: {str(e)}"
-        logger.error(error_msg)
+        error_msg = f"{log_ctx}Error getting authentication token for {endpoint}: {str(e)}"
         raise Exception(error_msg) from e
     except requests.exceptions.RequestException as e:
-        error_msg = f"Network error when calling {endpoint}: {str(e)}"
-        logger.error(error_msg)
+        error_msg = f"{log_ctx}Network error when calling {endpoint}: {str(e)}"
         raise Exception(error_msg) from e

--- a/dags/dependencies/ehr/utils.py
+++ b/dags/dependencies/ehr/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 import sys
 from datetime import datetime
@@ -36,21 +37,11 @@ def format_log_context(
     Args:
         site: Site name (e.g., 'synthea_54')
         delivery_date: Delivery date in YYYY-MM-DD format
-        file: Filename, table name, or file path
+        file: Filename, table name, or file path (extensions will be stripped)
 
     Returns:
         Formatted context string like "[site|delivery_date|file]" or subset.
         Returns empty string if no context provided.
-
-    Examples:
-        >>> format_log_context(site="synthea_54", delivery_date="2024-01-15", file="person.csv")
-        "[synthea_54|2024-01-15|person.csv] "
-        >>> format_log_context(site="synthea_54", delivery_date="2024-01-15")
-        "[synthea_54|2024-01-15] "
-        >>> format_log_context(site="synthea_54")
-        "[synthea_54] "
-        >>> format_log_context()
-        ""
     """
     parts = []
     if site:
@@ -58,7 +49,14 @@ def format_log_context(
     if delivery_date:
         parts.append(delivery_date)
     if file:
-        parts.append(file)
+        # Strip file extension for cleaner logging
+        # Extract just the basename if it's a full path
+        file_base = os.path.basename(file)
+        # Remove extension (handles .csv, .parquet, etc.)
+        file_without_ext, _ = os.path.splitext(file_base)
+        # Only add if we have a meaningful name (not just an extension like ".csv")
+        if file_without_ext:
+            parts.append(file_without_ext)
 
     return f"[{'|'.join(parts)}] " if parts else ""
 

--- a/dags/ehr_pipeline.py
+++ b/dags/ehr_pipeline.py
@@ -55,7 +55,7 @@ def check_api_health() -> None:
         raise
 
 
-@task(execution_timeout=timedelta(minutes=30))
+@task(execution_timeout=timedelta(minutes=15))
 def id_sites_to_process() -> list[tuple[str, str]]:
     """
     Identify sites with unprocessed or errored deliveries.
@@ -89,7 +89,7 @@ def end_if_all_processed(unprocessed_sites: list[tuple[str, str]]) -> bool:
     return True
 
 
-@task(execution_timeout=timedelta(minutes=15), trigger_rule="none_failed")
+@task(execution_timeout=timedelta(minutes=30), trigger_rule="none_failed")
 def get_unprocessed_files(sites_to_process: list[tuple[str, str]]) -> list[dict]:
     """
     Obtains list of EHR data files that need to be processed.

--- a/dags/ehr_pipeline.py
+++ b/dags/ehr_pipeline.py
@@ -19,6 +19,7 @@ from airflow.utils.dates import days_ago  # type: ignore
 from airflow.utils.task_group import TaskGroup  # type: ignore
 from airflow.utils.trigger_rule import TriggerRule  # type: ignore
 from dependencies.ehr.dag_helpers import (SiteConfig, TaskContext,
+                                          format_log_context,
                                           log_task_execution)
 from dependencies.ehr.storage_backend import storage
 
@@ -54,7 +55,7 @@ def check_api_health() -> None:
         raise
 
 
-@task(execution_timeout=timedelta(minutes=15))
+@task(execution_timeout=timedelta(minutes=30))
 def id_sites_to_process() -> list[tuple[str, str]]:
     """
     Identify sites with unprocessed or errored deliveries.
@@ -150,7 +151,9 @@ def convert_file(file_config_dict: dict) -> None:
         file_type=fc.file_delivery_format,
         gcs_file_path=fc.file_path,
         project_id=config.project_id,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        site=fc.site,
+        delivery_date=fc.delivery_date
     )
 
 
@@ -184,7 +187,10 @@ def normalize_file(file_config_dict: dict) -> None:
         date_format=fc.date_format,
         datetime_format=fc.datetime_format,
         project_id=config.project_id,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        site=fc.site,
+        delivery_date=fc.delivery_date,
+        file=fc.table_name
     )
 
 
@@ -196,11 +202,12 @@ def cdm_upgrade(file_config_dict: dict) -> None:
     """
     fc = file_config.FileConfig.from_dict(config_dict=file_config_dict)
     config = SiteConfig(site=fc.site)
+    log_ctx = format_log_context(site=fc.site, delivery_date=fc.delivery_date, file=fc.table_name)
 
     if fc.omop_version == constants.OMOP_TARGET_CDM_VERSION:
         utils.logger.info(
-            f"CDM version of {fc.file_path} ({fc.omop_version}) matches "
-            f"upgrade target {constants.OMOP_TARGET_CDM_VERSION}; upgrade not needed"
+            f"{log_ctx}CDM version ({fc.omop_version}) matches upgrade target "
+            f"{constants.OMOP_TARGET_CDM_VERSION}; skipping upgrade"
         )
     else:
         processing_jobs.run_upgrade_cdm_job(
@@ -208,7 +215,10 @@ def cdm_upgrade(file_config_dict: dict) -> None:
             cdm_version=fc.omop_version,
             target_cdm_version=constants.OMOP_TARGET_CDM_VERSION,
             project_id=config.project_id,
-            context=TaskContext.get_context()
+            context=TaskContext.get_context(),
+            site=fc.site,
+            delivery_date=fc.delivery_date,
+            file=fc.table_name
         )
 
 
@@ -237,7 +247,8 @@ def harmonize_vocab_source_target(file_config_dict: dict) -> None:
 
     # Check if this table should be harmonized
     if not vocab.should_harmonize_table(table_name=fc.table_name):
-        utils.logger.info(f"File {fc.table_name} is not a clinical data table and does not need vocabulary harmonization")
+        log_ctx = format_log_context(site=fc.site, delivery_date=fc.delivery_date, file=fc.table_name)
+        utils.logger.info(f"{log_ctx}Table is not a clinical data table; skipping vocabulary harmonization")
         raise AirflowSkipException
 
     # Get configuration parameters
@@ -250,7 +261,8 @@ def harmonize_vocab_source_target(file_config_dict: dict) -> None:
         project_id=config.project_id,
         dataset_id=config.cdm_dataset_id,
         step=constants.SOURCE_TARGET,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        delivery_date=fc.delivery_date
     )
 
 
@@ -276,7 +288,8 @@ def harmonize_vocab_target_remap(file_config_dict: dict) -> None:
         project_id=config.project_id,
         dataset_id=config.cdm_dataset_id,
         step=constants.TARGET_REMAP,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        delivery_date=fc.delivery_date
     )
 
 
@@ -302,7 +315,8 @@ def harmonize_vocab_target_replacement(file_config_dict: dict) -> None:
         project_id=config.project_id,
         dataset_id=config.cdm_dataset_id,
         step=constants.TARGET_REPLACEMENT,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        delivery_date=fc.delivery_date
     )
 
 
@@ -328,7 +342,8 @@ def harmonize_vocab_domain_check(file_config_dict: dict) -> None:
         project_id=config.project_id,
         dataset_id=config.cdm_dataset_id,
         step=constants.DOMAIN_CHECK,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        delivery_date=fc.delivery_date
     )
 
 
@@ -354,7 +369,8 @@ def harmonize_vocab_omop_etl(file_config_dict: dict) -> None:
         project_id=config.project_id,
         dataset_id=config.cdm_dataset_id,
         step=constants.OMOP_ETL,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        delivery_date=fc.delivery_date
     )
 
 
@@ -375,7 +391,8 @@ def harmonize_vocab_consolidate(site_to_process: tuple[str, str]) -> None:
         project_id=config.project_id,
         dataset_id=config.cdm_dataset_id,
         step=constants.CONSOLIDATE_ETL,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        delivery_date=delivery_date
     )
 
 
@@ -486,11 +503,11 @@ def prepare_bq(site_to_process: tuple[str, str]) -> None:
     """
     Deletes files and tables from previous pipeline runs.
     """
-    site, _ = site_to_process
+    site, delivery_date = site_to_process
     config = SiteConfig(site=site)
 
     # Delete all tables within the BigQuery dataset.
-    bq.prep_dataset(project_id=config.project_id, dataset_id=config.cdm_dataset_id)
+    bq.prep_dataset(project_id=config.project_id, dataset_id=config.cdm_dataset_id, site=site, delivery_date=delivery_date)
 
 
 @task(max_active_tis_per_dag=10, trigger_rule="none_failed", execution_timeout=timedelta(minutes=30))
@@ -506,7 +523,8 @@ def load_harmonized_tables(site_to_process: tuple[str, str]) -> None:
         gcs_bucket=config.gcs_bucket,
         delivery_date=delivery_date,
         project_id=config.project_id,
-        dataset_id=config.cdm_dataset_id
+        dataset_id=config.cdm_dataset_id,
+        site=site
     )
     
 
@@ -517,7 +535,7 @@ def load_target_vocab(site_to_process: tuple[str, str]) -> None:
     Load all target vocabulary tables to BigQuery
     If the site's overwrite_site_vocab_with_standard is False, the site's vocab tables will overwrite default tables loaded by this task
     """
-    site, _ = site_to_process
+    site, delivery_date = site_to_process
     config = SiteConfig(site=site)
 
     if config.overwrite_site_vocab_with_standard:
@@ -526,7 +544,9 @@ def load_target_vocab(site_to_process: tuple[str, str]) -> None:
                 vocab_version=constants.OMOP_TARGET_VOCAB_VERSION,
                 table_file_name=vocab_table,
                 project_id=config.project_id,
-                dataset_id=config.cdm_dataset_id
+                dataset_id=config.cdm_dataset_id,
+                site=site,
+                delivery_date=delivery_date
             )
 
 @task(max_active_tis_per_dag=24, trigger_rule="none_failed", execution_timeout=timedelta(minutes=30))
@@ -537,18 +557,19 @@ def load_remaining(file_config_dict: dict) -> None:
     """
     fc = file_config.FileConfig.from_dict(config_dict=file_config_dict)
     config = SiteConfig(site=fc.site)
+    log_ctx = format_log_context(site=fc.site, delivery_date=fc.delivery_date, file=fc.table_name)
 
     # Don't load standard vocabulary files if using site-specific vocabulary
     if config.overwrite_site_vocab_with_standard and fc.table_name in constants.VOCABULARY_TABLES:
-        utils.logger.info(f"Skip loading {fc.table_name} to BigQuery")
+        utils.logger.info(f"{log_ctx}Skipping vocabulary table load; using site-specific vocabulary")
         raise AirflowSkipException
 
     # Also skip vocab harmonized tables since they were already loaded in harmonize_vocab task
     elif fc.table_name in constants.VOCAB_HARMONIZED_TABLES:
-        utils.logger.info(f"Skip loading {fc.table_name} to BigQuery")
+        utils.logger.info(f"{log_ctx}Skipping load; already loaded in harmonize_vocab task")
         raise AirflowSkipException
     elif fc.table_name == "cdm_source":
-        utils.logger.info(f"Skip loading {fc.table_name} to BigQuery; handled in subsequent cleanup task")
+        utils.logger.info(f"{log_ctx}Skipping load; will be handled in cleanup task")
         raise AirflowSkipException
     else:
         bq.load_individual_parquet_to_bq(
@@ -556,7 +577,9 @@ def load_remaining(file_config_dict: dict) -> None:
             project_id=config.project_id,
             dataset_id=config.cdm_dataset_id,
             table_name=fc.table_name,
-            write_type=constants.BQWriteTypes.PROCESSED_FILE
+            write_type=constants.BQWriteTypes.PROCESSED_FILE,
+            site=fc.site,
+            delivery_date=fc.delivery_date
         )
 
 @task(max_active_tis_per_dag=10, trigger_rule="none_failed", execution_timeout=timedelta(minutes=30))
@@ -575,7 +598,8 @@ def load_derived_tables(site_to_process: tuple[str, str]) -> None:
         gcs_bucket=config.gcs_bucket,
         delivery_date=delivery_date,
         project_id=config.project_id,
-        dataset_id=config.cdm_dataset_id
+        dataset_id=config.cdm_dataset_id,
+        site=site
     )
 
 @task(trigger_rule="none_failed", execution_timeout=timedelta(minutes=30))
@@ -589,6 +613,7 @@ def cleanup(sites_to_process: list[tuple[str, str]]) -> None:
     for site, delivery_date in sites_to_process:
         config = SiteConfig(site=site)
         run_id = TaskContext.get_run_id()
+        log_ctx = format_log_context(site=site, delivery_date=delivery_date)
 
         try:
             bq.bq_log_running(site=site, delivery_date=delivery_date, run_id=run_id)
@@ -597,7 +622,9 @@ def cleanup(sites_to_process: list[tuple[str, str]]) -> None:
             omop.create_missing_omop_tables(
                 project_id=config.project_id,
                 dataset_id=config.cdm_dataset_id,
-                omop_version=constants.OMOP_TARGET_CDM_VERSION
+                omop_version=constants.OMOP_TARGET_CDM_VERSION,
+                site=site,
+                delivery_date=delivery_date
             )
 
             # Load cdm_source file to BigQuery (guaranteed to exist after populate_cdm_source_file task)
@@ -607,13 +634,15 @@ def cleanup(sites_to_process: list[tuple[str, str]]) -> None:
                 project_id=config.project_id,
                 dataset_id=config.cdm_dataset_id,
                 table_name="cdm_source",
-                write_type=constants.BQWriteTypes.PROCESSED_FILE
+                write_type=constants.BQWriteTypes.PROCESSED_FILE,
+                site=site,
+                delivery_date=delivery_date
             )
 
-            utils.logger.info(f"Final CDM cleanup completed for {site} delivery {delivery_date}")
+            utils.logger.info(f"{log_ctx}CDM cleanup and setup completed successfully")
         except Exception as e:
             bq.bq_log_error(site=site, delivery_date=delivery_date, run_id=run_id, message=str(e))
-            raise Exception(f"Unable to perform CDM cleanup: {e}") from e
+            raise Exception(f"{log_ctx}Unable to perform CDM cleanup: {e}") from e
 
 
 @task(max_active_tis_per_dag=10, trigger_rule="none_failed", execution_timeout=timedelta(minutes=30))
@@ -627,8 +656,9 @@ def generate_report_csv(site_to_process: tuple[str, str]) -> None:
     """
     site, delivery_date = site_to_process
     config = SiteConfig(site=site)
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date)
 
-    utils.logger.info(f"Generating delivery report CSV for {site} data delivered on {delivery_date}")
+    utils.logger.info(f"{log_ctx}Generating delivery report CSV")
 
     # Execute report generation via Cloud Run Job
     processing_jobs.run_generate_report_csv_job(
@@ -648,10 +678,12 @@ def generate_report_csv(site_to_process: tuple[str, str]) -> None:
 @task(max_active_tis_per_dag=10, trigger_rule="none_failed", execution_timeout=timedelta(hours=3))
 @log_task_execution()
 def dqd(site_to_process: tuple[str, str]) -> None:
+    """Execute the Data Quality Dashboard (DQD) checks via Cloud Run Job."""
     site, delivery_date = site_to_process
     config = SiteConfig(site=site)
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date)
 
-    utils.logger.info(f"Triggering DQD checks for {site} data delivered on {delivery_date}")
+    utils.logger.info(f"{log_ctx}Triggering DQD (Data Quality Dashboard) checks")
 
     gcs_artifact_path = f"{config.gcs_bucket}/{delivery_date}/{constants.ArtifactPaths.DQD.value}"
 
@@ -663,16 +695,21 @@ def dqd(site_to_process: tuple[str, str]) -> None:
         gcs_artifact_path=gcs_artifact_path,
         cdm_version=constants.OMOP_TARGET_CDM_VERSION,
         cdm_source_name=config.display_name,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        site=site,
+        delivery_date=delivery_date
     )
 
 @task(max_active_tis_per_dag=10, trigger_rule="none_failed", execution_timeout=timedelta(hours=3))
 @log_task_execution()
 def achilles(site_to_process: tuple[str, str]) -> None:
+    
+
     site, delivery_date = site_to_process
     config = SiteConfig(site=site)
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date)
 
-    utils.logger.info(f"Triggering Achilles analyses for {site} data delivered on {delivery_date}")
+    utils.logger.info(f"{log_ctx}Triggering Achilles analyses")
 
     gcs_artifact_path = f"{config.gcs_bucket}/{delivery_date}/{constants.ArtifactPaths.ACHILLES.value}"
 
@@ -685,22 +722,28 @@ def achilles(site_to_process: tuple[str, str]) -> None:
         gcs_artifact_path=gcs_artifact_path,
         cdm_version=constants.OMOP_TARGET_CDM_VERSION,
         cdm_source_name=config.display_name,
-        context=TaskContext.get_context()
+        context=TaskContext.get_context(),
+        site=site,
+        delivery_date=delivery_date
     )
 
 @task(max_active_tis_per_dag=10, trigger_rule="none_failed", execution_timeout=timedelta(minutes=30))
 @log_task_execution()
 def atlas_results_tables(site_to_process: tuple[str, str]) -> None:
+    """Run Atlas results tables creation via API endpoint."""
     site, delivery_date = site_to_process
     config = SiteConfig(site=site)
+    log_ctx = format_log_context(site=site, delivery_date=delivery_date)
 
-    utils.logger.info(f"Creating Atlas results tables for {site} data delivered on {delivery_date}")
+    utils.logger.info(f"{log_ctx}Creating Atlas results tables")
 
     # Create Atlas results tables via API endpoint
     analysis.create_atlas_results_tables(
         project_id=config.project_id,
         cdm_dataset_id=config.cdm_dataset_id,
-        analytics_dataset_id=config.analytics_dataset_id
+        analytics_dataset_id=config.analytics_dataset_id,
+        site=site,
+        delivery_date=delivery_date
     )
 
 @task(trigger_rule="none_failed", execution_timeout=timedelta(minutes=10))


### PR DESCRIPTION
- Add extensive logging messages to DAG output, always showing the site name, delivery date, and file being processed (where possible). This makes tracking process during multi-site runs easier.
- Create a new task for report file generation, called as a Google Job
- Skip harmonization task if there are no harmonized files to load, instead of failing entire DAG
- Add and update comments throughout codebase